### PR TITLE
BUG: `.gitattributes` to strip output from `.ipynb` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb filter=strip-notebook-output-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/__pycache__/**
 **/tmp/**
 !.gitignore
+!.gitattributes

--- a/tests/integration/test_pqtools.ipynb
+++ b/tests/integration/test_pqtools.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Import packages\n",
+    "\n",
     "from pathlib import Path\n",
     "from zolltools.db import pqtools as pqt"
    ]
@@ -51,24 +53,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
-  },
-  "orig_nbformat": 4
+   "name": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
## Issue

- #31 

## Resources

- [33eyes/commit_jupyter_notebooks_code_to_git_and_keep_output_locally.md](https://gist.github.com/33eyes/431e3d432f73371509d176d0dfb95b6e)
- [How to clear Jupyter Notebook's output and metadata when using git commit?](https://stackoverflow.com/questions/73218304/how-to-clear-jupyter-notebooks-output-and-metadata-when-using-git-commit)