### PR TITLE
ENH: Convenience methods for `pqtools`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zolltools"
-version = "0.0.6.dev5"
+version = "0.0.6.dev6"
 authors = [
   { name="Joshua Shew", email="joshua.t.shew@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zolltools"
-version = "0.0.6.dev9"
+version = "0.0.6.dev10"
 authors = [
   { name="Joshua Shew", email="joshua.t.shew@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zolltools"
-version = "0.0.6.dev6"
+version = "0.0.6.dev7"
 authors = [
   { name="Joshua Shew", email="joshua.t.shew@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zolltools"
-version = "0.0.6.dev7"
+version = "0.0.6.dev8"
 authors = [
   { name="Joshua Shew", email="joshua.t.shew@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zolltools"
-version = "0.0.6.dev8"
+version = "0.0.6.dev9"
 authors = [
   { name="Joshua Shew", email="joshua.t.shew@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zolltools"
-version = "0.0.6.dev10"
+version = "0.0.6.dev11"
 authors = [
   { name="Joshua Shew", email="joshua.t.shew@gmail.com" },
 ]

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -168,7 +168,13 @@ class ParquetManager:
         return num_rows
 
     def get_columns(self, pq_name: str, tmp: bool = True) -> list[str]:
-        """docstring"""
+        """
+        Returns the columns in a parquet table.
+
+        :param pq_name: the name of the table.
+        :param tmp: the directory the file is in.
+        :returns: the columns in the table.
+        """
 
         pq_file, _ = self._get_parquet_file(pq_name, tmp)
         return [column.name for column in pq_file.schema]

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -167,6 +167,12 @@ class ParquetManager:
         )
         return num_rows
 
+    def get_columns(self, pq_name: str, tmp: bool = True) -> list[str]:
+        """docstring"""
+
+        pq_file, _ = self._get_parquet_file(pq_name, tmp)
+        return [column.name for column in pq_file.schema]
+
     def get_tables(self, tmp=True) -> list:
         """
         Returns a list of the names of parquet tables in the database.

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -195,19 +195,19 @@ class Reader(ParquetManager):
 
         return None
 
-    def get_table(self, pq_name: str, tmp: bool) -> pd.DataFrame:
+    def get_table(self, pq_name: str, tmp: bool, columns=None) -> pd.DataFrame:
         """
-        🚧 WIP 🚧 Gets a table (`pq_name`) from the database.
+        Gets a table (`pq_name`) from the database.
 
         :param pq_name: the name (w/o file extension) of the file to read
         :param tmp: whether to get the table from temporary storage or from the
         data directory
         """
 
-        _ = pq_name
-        _ = tmp
+        pq_file, _ = self._get_parquet_file(pq_name, tmp)
+        table = pq_file.read(columns=columns, use_pandas_metadata=True)
 
-        return pd.DataFrame()
+        return table.to_pandas()
 
     def get_reader(
         self, pq_name: str, columns=None, target_in_memory_size=None, tmp=True

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -4,6 +4,7 @@ import os
 import math
 import logging
 from pathlib import Path
+from typing import Tuple
 from types import GeneratorType
 
 import pandas as pd
@@ -84,7 +85,7 @@ class ParquetManager:
 
         return self.config.tmp_path if tmp else self.config.db_path
 
-    def _get_parquet_file(self, pq_name: str, tmp=True) -> tuple:
+    def _get_parquet_file(self, pq_name: str, tmp=True) -> Tuple[pq.ParquetFile, Path]:
         """
         Returns the parquet file object and Path object given the name (w/o the
         file extension) of a parquet file.
@@ -194,7 +195,7 @@ class Reader(ParquetManager):
 
         return None
 
-    def get_table(self) -> pd.DataFrame:
+    def get_table(self, pq_name: str, tmp: bool) -> pd.DataFrame:
         """
         🚧 WIP 🚧 Gets a table (`pq_name`) from the database.
 
@@ -202,6 +203,9 @@ class Reader(ParquetManager):
         :param tmp: whether to get the table from temporary storage or from the
         data directory
         """
+
+        _ = pq_name
+        _ = tmp
 
         return pd.DataFrame()
 

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -189,6 +189,11 @@ class Reader(ParquetManager):
         for batch in pq_iter:
             yield batch.to_pandas()
 
+    def get_metadata(self):
+        """Docstring"""
+
+        return None
+
     def get_table(self, pq_name: str, tmp=True) -> pd.DataFrame:
         """
         🚧 WIP 🚧 Gets a table (`pq_name`) from the database.

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -194,7 +194,7 @@ class Reader(ParquetManager):
 
         return None
 
-    def get_table(self, pq_name: str, tmp=True) -> pd.DataFrame:
+    def get_table(self) -> pd.DataFrame:
         """
         🚧 WIP 🚧 Gets a table (`pq_name`) from the database.
 
@@ -202,6 +202,8 @@ class Reader(ParquetManager):
         :param tmp: whether to get the table from temporary storage or from the
         data directory
         """
+
+        return pd.DataFrame()
 
     def get_reader(
         self, pq_name: str, columns=None, target_in_memory_size=None, tmp=True

--- a/src/zolltools/db/pqtools.py
+++ b/src/zolltools/db/pqtools.py
@@ -4,7 +4,7 @@ import os
 import math
 import logging
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Union
 from types import GeneratorType
 
 import pandas as pd
@@ -195,13 +195,17 @@ class Reader(ParquetManager):
 
         return None
 
-    def get_table(self, pq_name: str, tmp: bool, columns=None) -> pd.DataFrame:
+    def get_table(
+        self, pq_name: str, tmp: bool, columns: Union[list[str], None] = None
+    ) -> pd.DataFrame:
         """
         Gets a table (`pq_name`) from the database.
 
         :param pq_name: the name (w/o file extension) of the file to read
         :param tmp: whether to get the table from temporary storage or from the
         data directory
+        :param columns: the columns to read from the table
+        :returns: a data frame representing the table that was read
         """
 
         pq_file, _ = self._get_parquet_file(pq_name, tmp)

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -67,3 +67,18 @@ def test_get_table(
         table_path.name.removesuffix(".parquet"), tmp=False
     )
     pd.testing.assert_frame_equal(frame, loaded_frame)
+
+
+def test_get_table_warning(
+    tmp_table_3x3: Tuple[Path, pd.DataFrame]
+):  # pylint: disable=redefined-outer-name
+    """
+    Tests if get_table returns a warning when the requested table is too large
+    """
+
+    table_path, _ = tmp_table_3x3
+    data_dir = table_path.parent
+    pq_config = pqtools.ParquetManager.Config(data_dir, default_target_in_memory_size=1)
+    pq_reader = pqtools.Reader(pq_config)
+    with pytest.raises(MemoryError, match=""):
+        _ = pq_reader.get_table(table_path.name.removesuffix(".parquet"), tmp=False)

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -1,0 +1,54 @@
+"""Tests for pqtools.py"""
+
+import os
+import contextlib
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from zolltools.db import pqtools
+
+
+@contextlib.contextmanager
+def temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
+    """Docstring"""
+
+    table_id = str(pd.util.hash_pandas_object(frame).sum() % 1_000_000).zfill(6)
+    temporary_directory = Path.cwd().joinpath(f"tmp_parquet_table_{table_id}")
+    temporary_directory.mkdir(exist_ok=True)
+    table = pa.Table.from_pandas(frame)
+    table_path = temporary_directory.joinpath(f"{table_id}.parquet")
+    pq.write_table(table, table_path)
+    try:
+        yield table_path
+    finally:
+        os.remove(table_path)
+        temporary_directory.rmdir()
+
+
+@pytest.fixture(scope="module")
+def tmp_table_3x3() -> Tuple[Path, pd.DataFrame]:
+    """docstring"""
+
+    frame = pd.DataFrame(np.arange(1, 10).reshape(3, 3))
+    with temporary_parquet_table_context_manager(frame) as table_path:
+        yield (table_path, frame)
+
+
+def test_get_table(
+    tmp_table_3x3: Tuple[Path, pd.DataFrame]
+):  # pylint: disable=redefined-outer-name
+    """docstring"""
+
+    table_path, frame = tmp_table_3x3
+    data_dir = table_path.parent
+    pq_config = pqtools.ParquetManager.Config(data_dir)
+    pq_reader = pqtools.Reader(pq_config)
+    loaded_frame = pq_reader.get_table(  # pylint: disable=assignment-from-no-return
+        table_path.name.removesuffix(".parquet"), tmp=False
+    )
+    pd.testing.assert_frame_equal(frame, loaded_frame)

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import random
 import contextlib
 from pathlib import Path
 from typing import Tuple
@@ -24,7 +25,10 @@ def _temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
     :returns: the path to the temporary table
     """
 
-    table_id = str(pd.util.hash_pandas_object(frame).sum() % 1_000_000).zfill(6)
+    randomizer = random.randint(1, 100_000)
+    table_id = str(
+        (pd.util.hash_pandas_object(frame).sum() % 900_000) + randomizer
+    ).zfill(6)
     temporary_directory = Path.cwd().joinpath(f"tmp_parquet_table_{table_id}")
     temporary_directory.mkdir(exist_ok=True)
     table = pa.Table.from_pandas(frame)

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -14,8 +14,14 @@ from zolltools.db import pqtools
 
 
 @contextlib.contextmanager
-def temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
-    """Docstring"""
+def _temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
+    """
+    Context manager for a temporary parquet table (used for testing). The
+    context manager will delete the temporary directory and table upon closing.
+
+    :param frame: the data frame to make into a parquet table
+    :returns: the path to the temporary table
+    """
 
     table_id = str(pd.util.hash_pandas_object(frame).sum() % 1_000_000).zfill(6)
     temporary_directory = Path.cwd().joinpath(f"tmp_parquet_table_{table_id}")
@@ -32,17 +38,25 @@ def temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
 
 @pytest.fixture(scope="module")
 def tmp_table_3x3() -> Tuple[Path, pd.DataFrame]:
-    """docstring"""
+    """
+    Fixture of a temporary parquet table to use for tests.
+
+    :returns: (path to table, data frame that was stored as a parquet table)
+    """
 
     frame = pd.DataFrame(np.arange(1, 10).reshape(3, 3))
-    with temporary_parquet_table_context_manager(frame) as table_path:
+    with _temporary_parquet_table_context_manager(frame) as table_path:
         yield (table_path, frame)
 
 
 def test_get_table(
     tmp_table_3x3: Tuple[Path, pd.DataFrame]
 ):  # pylint: disable=redefined-outer-name
-    """docstring"""
+    """
+    Tests get_table with a simple table
+
+    :param tmp_table_3x3: a pytest fixture
+    """
 
     table_path, frame = tmp_table_3x3
     data_dir = table_path.parent

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -108,7 +108,7 @@ def test_get_table_warning(
     pd.testing.assert_frame_equal(frame, loaded_frame)
 
 
-@pytest.mark.xfail
+# @pytest.mark.xfail
 def test_get_column_list(
     tmp_table_3x3_named_cols: Tuple[Path, pd.DataFrame]
 ):  # pylint: disable=redefined-outer-name
@@ -118,4 +118,6 @@ def test_get_column_list(
     data_dir = table_path.parent
     pq_config = pqtools.ParquetManager.Config(data_dir)
     pq_reader = pqtools.Reader(pq_config)
-    assert frame.columns == pq_reader.get_columns()  # pylint: disable=no-member
+    assert list(frame.columns) == pq_reader.get_columns(
+        table_path.name.removesuffix(".parquet"), tmp=False
+    )  # pylint: disable=no-member

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -73,12 +73,21 @@ def test_get_table_warning(
     tmp_table_3x3: Tuple[Path, pd.DataFrame]
 ):  # pylint: disable=redefined-outer-name
     """
-    Tests if get_table returns a warning when the requested table is too large
+    Tests if get_table returns a warning when the requested table is too large.
     """
 
-    table_path, _ = tmp_table_3x3
+    table_path, frame = tmp_table_3x3
     data_dir = table_path.parent
     pq_config = pqtools.ParquetManager.Config(data_dir, default_target_in_memory_size=1)
     pq_reader = pqtools.Reader(pq_config)
     with pytest.raises(MemoryError):
         _ = pq_reader.get_table(table_path.name.removesuffix(".parquet"), tmp=False)
+
+    pq_config = pqtools.ParquetManager.Config(
+        data_dir, default_target_in_memory_size=1000
+    )
+    pq_reader = pqtools.Reader(pq_config)
+    loaded_frame = pq_reader.get_table(
+        table_path.name.removesuffix(".parquet"), tmp=False
+    )
+    pd.testing.assert_frame_equal(frame, loaded_frame)

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -33,6 +33,7 @@ def _temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
         yield table_path
     finally:
         os.remove(table_path)
+        temporary_directory.joinpath("tmp").rmdir()
         temporary_directory.rmdir()
 
 

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -108,11 +108,10 @@ def test_get_table_warning(
     pd.testing.assert_frame_equal(frame, loaded_frame)
 
 
-# @pytest.mark.xfail
-def test_get_column_list(
+def test_get_column(
     tmp_table_3x3_named_cols: Tuple[Path, pd.DataFrame]
 ):  # pylint: disable=redefined-outer-name
-    """docstring"""
+    """Tests get_column method"""
 
     table_path, frame = tmp_table_3x3_named_cols
     data_dir = table_path.parent

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -108,6 +108,7 @@ def test_get_table_warning(
     pd.testing.assert_frame_equal(frame, loaded_frame)
 
 
+@pytest.mark.xfail
 def test_get_column_list(
     tmp_table_3x3_named_cols: Tuple[Path, pd.DataFrame]
 ):  # pylint: disable=redefined-outer-name

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -1,6 +1,7 @@
 """Tests for pqtools.py"""
 
 import os
+import shutil
 import contextlib
 from pathlib import Path
 from typing import Tuple
@@ -33,8 +34,7 @@ def _temporary_parquet_table_context_manager(frame: pd.DataFrame) -> Path:
         yield table_path
     finally:
         os.remove(table_path)
-        temporary_directory.joinpath("tmp").rmdir()
-        temporary_directory.rmdir()
+        shutil.rmtree(temporary_directory)
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -63,7 +63,7 @@ def test_get_table(
     data_dir = table_path.parent
     pq_config = pqtools.ParquetManager.Config(data_dir)
     pq_reader = pqtools.Reader(pq_config)
-    loaded_frame = pq_reader.get_table(  # pylint: disable=assignment-from-no-return
+    loaded_frame = pq_reader.get_table(
         table_path.name.removesuffix(".parquet"), tmp=False
     )
     pd.testing.assert_frame_equal(frame, loaded_frame)

--- a/tests/unit/test_pqtools.py
+++ b/tests/unit/test_pqtools.py
@@ -80,5 +80,5 @@ def test_get_table_warning(
     data_dir = table_path.parent
     pq_config = pqtools.ParquetManager.Config(data_dir, default_target_in_memory_size=1)
     pq_reader = pqtools.Reader(pq_config)
-    with pytest.raises(MemoryError, match=""):
+    with pytest.raises(MemoryError):
         _ = pq_reader.get_table(table_path.name.removesuffix(".parquet"), tmp=False)

--- a/tests/unit/test_strtools.py
+++ b/tests/unit/test_strtools.py
@@ -21,7 +21,7 @@ def test_removeprefix_empty_prefix(string: str):
 
 
 @pytest.mark.parametrize(
-    ("input", "prefix", "expected"),
+    ("string", "prefix", "expected"),
     [
         ("abcabcabc", "abc", "abcabc"),
         ("abc123456", "abc", "123456"),
@@ -35,7 +35,7 @@ def test_removeprefix_with_matching_prefix(string, prefix, expected):
 
 
 @pytest.mark.parametrize(
-    ("input", "prefix"),
+    ("string", "prefix"),
     [
         ("abcabcabc", "bac"),
         ("abc123456", "123"),
@@ -63,7 +63,7 @@ def test_removesuffix_empty_suffix(string: str):
 
 
 @pytest.mark.parametrize(
-    ("input", "suffix", "expected"),
+    ("string", "suffix", "expected"),
     [
         ("abcabcabc", "abc", "abcabc"),
         ("abc123456", "456", "abc123"),
@@ -77,7 +77,7 @@ def test_removesuffix_with_matching_suffix(string, suffix, expected):
 
 
 @pytest.mark.parametrize(
-    ("input", "suffix"),
+    ("string", "suffix"),
     [
         ("abcabcabc", "bac"),
         ("abc123456", "123"),


### PR DESCRIPTION
## Issue

- [x] #30 
- [x] #90 
- [x] #83 

## Resources

- [pyarrow.parquet.ParquetFile.metadata](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html#pyarrow.parquet.ParquetFile.metadata)
- [pyarrow.parquet.ParquetFile.schema](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html#pyarrow.parquet.ParquetFile.schema)
- [pyarrow.parquet.ParquetSchema](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetSchema.html#pyarrow.parquet.ParquetSchema)
- [pyarrow.parquet.ColumnSchema](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ColumnSchema.html#pyarrow.parquet.ColumnSchema)
- 